### PR TITLE
Hostnames & Single Branch Submodules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # simple default user
       - MARIADB_PASSWORD=aimlac
       - MARIADB_USER=aimlac
+    hostname: "aimlac-database"
 
   crawlers:
     image: nodered/node-red

--- a/update-all.sh
+++ b/update-all.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git submodule update --init --recursive
-git submodule update --remote --merge
+git submodule update --init --recursive --depth 1 --single-branch
+git submodule update --remote --merge --depth 1 --single-branch


### PR DESCRIPTION
Added hostnames to the database container so we can access it on the docker-compose network by name, instead of IP address.

Updated submodules, and now only graft clone depth 1 on the main branch.